### PR TITLE
show latest clojars version in readme

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,7 +19,7 @@ h2. Installation
 Drop the following dependency in your <code>project.clj</code> at the appropriate place:
 
 <pre>
-[ring-basic-authentication "0.0.1"]
+[ring-basic-authentication "1.0.1"]
 </pre>
 
 


### PR DESCRIPTION
I was blindly following the `README` while attempting to utilize this middleware and was wondering why it wasn't working as advertised.  Thought I'd just bump the version so others don't get stuck as well.
