### PR TITLE
Avoid reflection by adding type hints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,6 @@
 
   :codox {:output-path    "doc"
           :source-dir-uri ""
-          :source-uri     "https://github.com/remvee/ring-basic-authentication/blob/{git-commit}/{filepath}#L{line}"})
+          :source-uri     "https://github.com/remvee/ring-basic-authentication/blob/{git-commit}/{filepath}#L{line}"}
+
+  :global-vars {*warn-on-reflection* true})

--- a/src/ring/middleware/basic_authentication.clj
+++ b/src/ring/middleware/basic_authentication.clj
@@ -18,18 +18,18 @@
   was raised."
   [direction-fn string]
   (try
-    (s/join (map char (direction-fn (.getBytes string))))
+    (s/join (map char (direction-fn (.getBytes ^String string))))
     (catch Exception _)))
 
 (defn- encode-base64
   "Will do a base64 encoding of a string and return a string."
   [^String string]
-  (byte-transform #(.encode (Base64/getEncoder) %) string))
+  (byte-transform #(.encode ^java.util.Base64$Encoder (Base64/getEncoder) ^bytes %) string))
 
 (defn- decode-base64
   "Will do a base64 decoding of a string and return a string."
   [^String string]
-  (byte-transform #(.decode (Base64/getDecoder) %) string))
+  (byte-transform #(.decode ^java.util.Base64$Decoder (Base64/getDecoder) ^bytes %) string))
 
 (defn basic-authentication-request
   "Authenticates the given request against using auth-fn. The value


### PR DESCRIPTION
Makes it possible to use e.g. GraalVM